### PR TITLE
Remove deprecated parameter 'use_gui'

### DIFF
--- a/launch/display_urdf.launch
+++ b/launch/display_urdf.launch
@@ -8,7 +8,7 @@
   <param name="robot_description" textfile="$(arg model)" />
   <param name="use_gui" value="$(arg gui)" />
   <!-- nodes -->
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
   <!-- rviz -->
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(arg rvizconfig)" required="true" />

--- a/launch/display_xacro.launch
+++ b/launch/display_xacro.launch
@@ -7,7 +7,7 @@
   <param name="robot_description" command="$(find xacro)/xacro.py $(arg model)" />
   <param name="use_gui" value="$(arg gui)" />
 
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" required="true" args="-d $(arg rvizconfig)" />
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
   <build_depend>urdf</build_depend>
 
   <run_depend>urdf</run_depend>
+  <run_depend>joint_state_publisher_gui</run_depend>
 
   <export>
 


### PR DESCRIPTION
#7 のエラーを解決するため、joint_state_publisher_guiを使うように変更しました。