### PR TITLE
Fix depricated VelocityJointInterface definition

### DIFF
--- a/urdf/raspimouse.urdf.xacro
+++ b/urdf/raspimouse.urdf.xacro
@@ -50,8 +50,8 @@
   <!-- <xacro:wheel_trans prefix="left" interface="PositionJointInterface"/>  -->
   <!-- VelocityJointInterface: requires position, velocity -->
   <!-- for DiffDriveController -->
-  <xacro:wheel_trans prefix="right" interface="VelocityJointInterface"/>
-  <xacro:wheel_trans prefix="left" interface="VelocityJointInterface"/>
+  <xacro:wheel_trans prefix="right" interface="hardware_interface/VelocityJointInterface"/>
+  <xacro:wheel_trans prefix="left" interface="hardware_interface/VelocityJointInterface"/>
   <!-- EffortJointInterface: requires position, velocity, effort -->
   <!-- <xacro:wheel_trans prefix="right" interface="EffortJointInterface"/> -->
   <!-- <xacro:wheel_trans prefix="left" interface="EffortJointInterface"/>  -->

--- a/urdf/raspimouse_urg.urdf.xacro
+++ b/urdf/raspimouse_urg.urdf.xacro
@@ -53,8 +53,8 @@
   <!-- ===============  Transmission =============== -->
   <!-- <xacro:wheel_trans prefix="right" interface="EffortJointInterface"/> -->
   <!-- <xacro:wheel_trans prefix="left" interface="EffortJointInterface"/> -->
-  <xacro:wheel_trans prefix="right" interface="VelocityJointInterface"/>
-  <xacro:wheel_trans prefix="left" interface="VelocityJointInterface"/>
+  <xacro:wheel_trans prefix="right" interface="hardware_interface/VelocityJointInterface"/>
+  <xacro:wheel_trans prefix="left" interface="hardware_interface/VelocityJointInterface"/>
 
   <!-- =============== Gazebo =============== -->
   <gazebo>


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING document.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.

# What does this implement/fix? Explain your changes.
<!-- このPRはどんな機能改善/修正ですか？ -->
```
[ WARN] [1589795683.996180612, 0.267000000]: Deprecated syntax, please prepend 'hardware_interface/' to 'VelocityJointInterface' within the <hardwareInterface> tag in joint 'left_wheel_joint'.
```

Gazebo起動時に上記の警告が出ます。これを修正します。
raspimouse_simでは https://github.com/rt-net/raspimouse_sim/pull/19 にて当時default branchであったkinetic-branchのみ修正されていました。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

関連 #12 

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

https://github.com/Tiryoh/docker_ros-desktop-vnc を用いて以下の通り実行してシミュレータが起動することを確認しました。

```
cd ~/catkin_ws/src
git clone https://github.com/rt-net/raspimouse_sim.git
git clone https://github.com/rt-net/raspimouse_description.git
(cd ~/catkin_ws/src/raspimouse_sim  && git checkout issue/36/separate_description)
(cd ~/catkin_ws/src/raspimouse_description  && git checkout issue/12/fix_joint_interface)
rosdep install -r -y -i --from-paths raspimouse*
catkin build
catkin source
roslaunch raspimouse_gazebo raspimouse_with_samplemaze.launch use_devfile:=false
```