### PR TITLE
Replace deprecated robot_state_publisher

### DIFF
--- a/launch/display_urdf.launch
+++ b/launch/display_urdf.launch
@@ -9,7 +9,7 @@
   <param name="use_gui" value="$(arg gui)" />
   <!-- nodes -->
   <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <!-- rviz -->
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(arg rvizconfig)" required="true" />
 </launch>

--- a/launch/display_xacro.launch
+++ b/launch/display_xacro.launch
@@ -8,6 +8,6 @@
   <param name="use_gui" value="$(arg gui)" />
 
   <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" required="true" args="-d $(arg rvizconfig)" />
 </launch>


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING document.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.

# What does this implement/fix? Explain your changes.
<!-- このPRはどんな機能改善/修正ですか？ -->

`robot_state_publisher/state_publisher`は`robot_state_publisher/robot_state_publisher`に移行していて使用非推奨です。これをリプレースします。
後方互換性のために`robot_state_publisher/state_publisher`のバイナリが生成されていますが、noeticではこのバイナリが存在しません。
参考: https://github.com/ros/robot_state_publisher/pull/87

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
関連: https://github.com/rt-net/raspimouse_description/issues/7

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
https://github.com/Tiryoh/docker_ros-desktop-vnc を用いて以下の通り実行してシミュレータが起動することを確認しました。

```
cd ~/catkin_ws/src
git clone https://github.com/rt-net/raspimouse_sim.git
git clone https://github.com/rt-net/raspimouse_description.git
(cd ~/catkin_ws/src/raspimouse_sim  && git checkout issue/36/separate_description)
(cd ~/catkin_ws/src/raspimouse_description  && git checkout issue/7/replace_depricated_state_publisher)
rosdep install -r -y -i --from-paths raspimouse*
catkin build
catkin source
roslaunch raspimouse_gazebo raspimouse_with_samplemaze.launch use_devfile:=false
```

