### PR TITLE
Support for launching multiple robots

### DIFF
--- a/launch/display_xacro.launch
+++ b/launch/display_xacro.launch
@@ -8,6 +8,7 @@
   <arg name="urg" default="false" />
   <arg name="lidar_frame" default="laser" />
   <arg name="xacro_option" default="" />
+  <arg name="namespace" default="/" />
 
   <arg name="urg_option" value="lidar:='urg'" if="$(arg urg)" />
   <arg name="urg_option" value="lidar:='none'" unless="$(arg urg)" />
@@ -17,8 +18,9 @@
   <!-- in-order processing (\-\-inorder option) became default in ROS Melodic -->
   <param name="robot_description" command="$(find xacro)/xacro $(arg model) $(arg urg_option) lidar_frame:='$(arg lidar_frame)' $(arg xacro_option)" />
   <!-- nodes -->
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" unless="$(arg use_rviz)" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher">
+    <param name="tf_prefix" value="$(arg namespace)" />
+  </node>
 
   <!-- raspimouse urdf viewer -->
   <group if="$(arg use_rviz)">


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

複数ロボットの起動のために`robot_state_publisher`に`tf_prefix`のオプションを使用します。

Noeticでは一旦削除されその後再実装されたという経緯があり、1.15.2以降で利用できるようです。

https://github.com/ros/robot_state_publisher/pull/169

RVizを使わないときには[joint_state_controller](https://wiki.ros.org/joint_state_controller)を使う場面の方が多いと思うので`joint_state_publisher`を削除します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

`namespace`を指定するとprefixがつくことを確認できます。

```
roslaunch raspimouse_description display_xacro.launch use_rviz:=false namespace:=raspimouse1
```

![Screenshot from 2021-12-13 18-52-03](https://user-images.githubusercontent.com/3256629/145790029-4a95a32d-b790-4c37-97d2-55b16d457727.png)

先頭に`/`がつかないですがこれがrobot_state_publisherの挙動のようです。

https://answers.ros.org/question/43145/tf-namespace-resolution/


# Any other comments?
<!-- その他コメントはありますか？ -->

なし

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
