### PR TITLE
Update package.xml for ROS 2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,7 @@
   <depend>joint_state_publisher_gui</depend>
   <depend>joint_state_publisher</depend>
   <depend>robot_state_publisher</depend>
-  <depend>rviz</depend>
+  <depend>rviz2</depend>
   <depend>urdf</depend>
   <depend>xacro</depend>
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
ROS 2で使用する時、`rosdep install`でエラーが発生しなくなります。

```
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
raspimouse_description: Cannot locate rosdep definition for [rviz]
```

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
no

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
手元のマシンで該当コマンドを実行。
 * PC
   * Ubuntu 20.04
   * ROS 2 (Foxy)

```sh
$ rosdep install -r -y --from-paths . --ignore-src
#All required rosdeps installed successfully
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
