### PR TITLE
cmd_velとodomのトピック名をremapping

### DIFF
--- a/urdf/raspimouse.urdf.xacro
+++ b/urdf/raspimouse.urdf.xacro
@@ -11,7 +11,6 @@
   <xacro:arg name="tf" default="true" />
   <xacro:arg name="jointstate" default="true" />
   <xacro:arg name="robot_namespace" default="/" />
-  <xacro:arg name="topic_namespace" default="" />
   <xacro:arg name="sensor_namespace" default="raspimouse_on_gazebo" />
   <xacro:arg name="use_gazebo" default="false" />
   <xacro:arg name="gz_control_config_package" default="" />
@@ -104,8 +103,7 @@
     <xacro:gazebo_diffdrive_settings
       use_gazebo="$(arg use_gazebo)"
       config_file_package="$(arg gz_control_config_package)" 
-      config_file_path="$(arg gz_control_config_file_path)"
-      topic_namespace="$(arg topic_namespace)" />
+      config_file_path="$(arg gz_control_config_file_path)" />
 
     <xacro:diffdrive_gazebo_ros2_control_settings
       name_hardware="GazeboSystem"

--- a/urdf/raspimouse.urdf.xacro
+++ b/urdf/raspimouse.urdf.xacro
@@ -11,6 +11,7 @@
   <xacro:arg name="tf" default="true" />
   <xacro:arg name="jointstate" default="true" />
   <xacro:arg name="robot_namespace" default="/" />
+  <xacro:arg name="topic_namespace" default="" />
   <xacro:arg name="sensor_namespace" default="raspimouse_on_gazebo" />
   <xacro:arg name="use_gazebo" default="false" />
   <xacro:arg name="gz_control_config_package" default="" />
@@ -103,7 +104,8 @@
     <xacro:gazebo_diffdrive_settings
       use_gazebo="$(arg use_gazebo)"
       config_file_package="$(arg gz_control_config_package)" 
-      config_file_path="$(arg gz_control_config_file_path)" />
+      config_file_path="$(arg gz_control_config_file_path)"
+      topic_namespace="$(arg topic_namespace)" />
 
     <xacro:diffdrive_gazebo_ros2_control_settings
       name_hardware="GazeboSystem"

--- a/urdf/wheel/diffdrive.gazebo.xacro
+++ b/urdf/wheel/diffdrive.gazebo.xacro
@@ -7,13 +7,14 @@
     params="use_gazebo
             config_file_package
             config_file_path
+	    topic_namespace
             ">
 
     <gazebo>
       <xacro:if value="${use_gazebo}">
         <plugin filename="libign_ros2_control-system.so" name="ign_ros2_control::IgnitionROS2ControlPlugin">
           <ros>
-            <namespace></namespace>
+            <namespace>${topic_namespace}</namespace>
             <remapping>diff_drive_controller/cmd_vel_unstamped:=cmd_vel</remapping>
             <remapping>diff_drive_controller/odom:=odom</remapping>
           </ros>

--- a/urdf/wheel/diffdrive.gazebo.xacro
+++ b/urdf/wheel/diffdrive.gazebo.xacro
@@ -7,14 +7,12 @@
     params="use_gazebo
             config_file_package
             config_file_path
-	    topic_namespace
             ">
 
     <gazebo>
       <xacro:if value="${use_gazebo}">
         <plugin filename="libign_ros2_control-system.so" name="ign_ros2_control::IgnitionROS2ControlPlugin">
           <ros>
-            <namespace>${topic_namespace}</namespace>
             <remapping>diff_drive_controller/cmd_vel_unstamped:=cmd_vel</remapping>
             <remapping>diff_drive_controller/odom:=odom</remapping>
           </ros>

--- a/urdf/wheel/diffdrive.gazebo.xacro
+++ b/urdf/wheel/diffdrive.gazebo.xacro
@@ -12,6 +12,11 @@
     <gazebo>
       <xacro:if value="${use_gazebo}">
         <plugin filename="libign_ros2_control-system.so" name="ign_ros2_control::IgnitionROS2ControlPlugin">
+          <ros>
+            <namespace></namespace>
+            <remapping>diff_drive_controller/cmd_vel_unstamped:=cmd_vel</remapping>
+            <remapping>diff_drive_controller/odom:=odom</remapping>
+          </ros>
           <parameters>$(find ${config_file_package})/${config_file_path}</parameters>
         </plugin>
       </xacro:if>


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
URDFにおいてトピック名をremappingします。

- /diff_drive_controller/cmd_vel_unstamped -> /cmd_vel
- /diff_drive_controller/odom -> /odom

また、xacroのパラメータにnamespaceを追加します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
下記のコマンドを実行してGazeboシミュレータを起動します。
```sh
ros2 launch raspimouse_gazebo raspimouse_with_emptyworld.launch.py
```

別の端末で下記のコマンドを実行するとremappingされたトピック名を確認できます。
```sh
ros2 topic list
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
