### PR TITLE
camera_downwardがtrueのときRGBカメラが斜め下を向くように変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ Similarly, display a RGB Camera mounted robot model with the following command:
 ```sh
 ros2 launch raspimouse_description display.launch.py use_rgb_camera:=true
 ```
+![](https://rt-net.github.io/images/raspberry-pi-mouse/mouse_with_rgb_camera.png)
+
+RGB Camera can be pointed down with the following command:
+
+```sh
+ros2 launch raspimouse_description display.launch.py use_rgb_camera:=true camera_downward:=true
+```
+
+![](https://rt-net.github.io/images/raspberry-pi-mouse/mouse_with_rgb_camera_downward.png)
 
 ## LICENSE
 

--- a/launch/display.launch.py
+++ b/launch/display.launch.py
@@ -47,7 +47,7 @@ def generate_launch_description():
     declare_arg_camera_downward = DeclareLaunchArgument(
         'camera_downward',
         default_value='false',
-        description='Set "true" to camera down.')
+        description='Set "true" to point the camera downwards.')
 
     description_loader = RobotDescriptionLoader()
     description_loader.lidar = LaunchConfiguration('lidar')

--- a/launch/display.launch.py
+++ b/launch/display.launch.py
@@ -44,11 +44,16 @@ def generate_launch_description():
         'use_rgb_camera',
         default_value='false',
         description='Set "true" to mount rgb camera.')
+    declare_arg_camera_downward = DeclareLaunchArgument(
+        'camera_downward',
+        default_value='false',
+        description='Set "true" to camera down.')
 
     description_loader = RobotDescriptionLoader()
     description_loader.lidar = LaunchConfiguration('lidar')
     description_loader.lidar_frame = LaunchConfiguration('lidar_frame')
     description_loader.use_rgb_camera = LaunchConfiguration('use_rgb_camera')
+    description_loader.camera_downward = LaunchConfiguration('camera_downward')
 
     push_ns = PushRosNamespace([LaunchConfiguration('namespace')])
 
@@ -78,6 +83,7 @@ def generate_launch_description():
         declare_arg_namespace,
         declare_arg_use_rviz,
         declare_arg_use_rgb_camera,
+        declare_arg_camera_downward,
         push_ns,
         rsp,
         jsp,

--- a/raspimouse_description/robot_description_loader.py
+++ b/raspimouse_description/robot_description_loader.py
@@ -36,6 +36,7 @@ class RobotDescriptionLoader():
         self.lidar_frame = 'laser'
         self.use_gazebo = 'false'
         self.use_rgb_camera = 'false'
+        self.camera_downward = 'false'
         self.gz_control_config_package = ''
         self.gz_control_config_file_path = ''
 
@@ -47,6 +48,7 @@ class RobotDescriptionLoader():
                 ' lidar_frame:=', self.lidar_frame,
                 ' use_gazebo:=', self.use_gazebo,
                 ' use_rgb_camera:=', self.use_rgb_camera,
+                ' camera_downward:=', self.camera_downward,
                 ' gz_control_config_package:=', self.gz_control_config_package,
                 ' gz_control_config_file_path:=', self.gz_control_config_file_path
                 ])

--- a/test/test_robot_description_loader.py
+++ b/test/test_robot_description_loader.py
@@ -95,6 +95,7 @@ def test_use_rgb_camera():
     # use_rgb_cameraが変更され、xacroにRGB Cameraがセットされることを期待
     rdl = RobotDescriptionLoader()
     rdl.use_rgb_camera = 'true'
+    rdl.camera_downward = 'false'
     rdl.gz_control_config_package = 'raspimouse_description'
     rdl.gz_control_config_file_path = 'test/dummy_controllers.yaml'
     assert 'realsense2_description/meshes/d435.dae' in exec_load(rdl)
@@ -105,6 +106,19 @@ def test_camera_link():
     rdl = RobotDescriptionLoader()
     rdl.use_gazebo = 'true'
     rdl.use_rgb_camera = 'true'
+    rdl.camera_downward = 'false'
     rdl.gz_control_config_package = 'raspimouse_description'
     rdl.gz_control_config_file_path = 'test/dummy_controllers.yaml'
     assert 'camera_link' in exec_load(rdl)
+
+
+def test_camera_downward():
+    # camera_downwardが変更され、カメラが斜め30度下を向くことを期待
+    rdl = RobotDescriptionLoader()
+    rdl.use_gazebo = 'true'
+    rdl.use_rgb_camera = 'true'
+    rdl.camera_downward = 'true'
+    rdl.gz_control_config_package = 'raspimouse_description'
+    rdl.gz_control_config_file_path = 'test/dummy_controllers.yaml'
+    print(exec_load(rdl))
+    assert '<pose>0 0 0 0 0.523 0</pose>' in exec_load(rdl)

--- a/test/test_robot_description_loader.py
+++ b/test/test_robot_description_loader.py
@@ -105,7 +105,6 @@ def test_camera_link():
     rdl = RobotDescriptionLoader()
     rdl.use_gazebo = 'true'
     rdl.use_rgb_camera = 'true'
-    rdl.camera_downward = 'false'
     rdl.gz_control_config_package = 'raspimouse_description'
     rdl.gz_control_config_file_path = 'test/dummy_controllers.yaml'
     assert 'camera_link' in exec_load(rdl)

--- a/test/test_robot_description_loader.py
+++ b/test/test_robot_description_loader.py
@@ -95,7 +95,6 @@ def test_use_rgb_camera():
     # use_rgb_cameraが変更され、xacroにRGB Cameraがセットされることを期待
     rdl = RobotDescriptionLoader()
     rdl.use_rgb_camera = 'true'
-    rdl.camera_downward = 'false'
     rdl.gz_control_config_package = 'raspimouse_description'
     rdl.gz_control_config_file_path = 'test/dummy_controllers.yaml'
     assert 'realsense2_description/meshes/d435.dae' in exec_load(rdl)

--- a/test/test_robot_description_loader.py
+++ b/test/test_robot_description_loader.py
@@ -22,6 +22,7 @@
 from raspimouse_description.robot_description_loader import RobotDescriptionLoader
 from launch.launch_context import LaunchContext
 import pytest
+import math
 
 
 def exec_load(loader):
@@ -118,5 +119,5 @@ def test_camera_downward():
     rdl.camera_downward = 'true'
     rdl.gz_control_config_package = 'raspimouse_description'
     rdl.gz_control_config_file_path = 'test/dummy_controllers.yaml'
-    print(exec_load(rdl))
-    assert '<pose>0 0 0 0 0.523 0</pose>' in exec_load(rdl)
+    camera_angle = math.radians(30)
+    assert '<pose>0 0 0 0 ' + str(camera_angle) + ' 0</pose>' in exec_load(rdl)

--- a/urdf/raspimouse.urdf.xacro
+++ b/urdf/raspimouse.urdf.xacro
@@ -14,6 +14,7 @@
   <xacro:arg name="sensor_namespace" default="raspimouse_on_gazebo" />
   <xacro:arg name="use_gazebo" default="false" />
   <xacro:arg name="use_rgb_camera" default="false" />
+  <xacro:arg name="camera_downward" default="false" />
   <xacro:arg name="gz_control_config_package" default="" />
   <xacro:arg name="gz_control_config_file_path" default="" />
   
@@ -102,7 +103,8 @@
   <!-- =============== Gazebo =============== -->
   <xacro:rgb_camera_settings
     use_gazebo="$(arg use_gazebo)"
-    use_rgb_camera="$(arg use_rgb_camera)" />
+    use_rgb_camera="$(arg use_rgb_camera)"
+    camera_downward="$(arg camera_downward)" />
 
   <xacro:if value="$(arg use_gazebo)">
     <xacro:gazebo_diffdrive_settings

--- a/urdf/sensors/rgb_camera.xacro
+++ b/urdf/sensors/rgb_camera.xacro
@@ -3,6 +3,8 @@
 
   <xacro:include filename="$(find raspimouse_description)/urdf/common.xacro" />
 
+  <xacro:property name="CAMERA_ANGLE" value="${radians(30)}"/>
+
   <xacro:macro name="rgb_camera_settings"
     params="use_gazebo
             use_rgb_camera
@@ -17,7 +19,7 @@
         use_nominal_extrinsics="false"
         add_plug="false"
         use_mesh="true">
-          <origin xyz="0.08 0.0 0.055" rpy="0 0.523 0"/>
+          <origin xyz="0.08 0.0 0.055" rpy="0 ${CAMERA_ANGLE} 0"/>
       </xacro:sensor_d435>
     </xacro:if>
 
@@ -39,53 +41,32 @@
       </plugin>
     </gazebo>
 
-    <xacro:if value="${camera_downward}">
-      <gazebo reference="camera_link">
-        <sensor name="camera_link" type="camera">
-          <update_rate>30.0</update_rate>
-          <always_on>true</always_on>
-          <ignition_frame_id>camera_link</ignition_frame_id>
-          <pose>0 0 0 0 ${radians(30)} 0</pose>
-          <topic>/camera/color/image_raw</topic>
-          <camera name="rgb_camera">
-            <horizontal_fov>1.20428</horizontal_fov>
-            <image>
-              <width>1920</width>
-              <height>1080</height>
-              <format>R8G8B8</format>
-            </image>
-            <clip>
-              <near>0.02</near>
-              <far>300</far>
-            </clip>
-          </camera>
-        </sensor>
-      </gazebo>
-    </xacro:if>
-
-    <xacro:unless value="${camera_downward}">
-      <gazebo reference="camera_link">
-        <sensor name="camera_link" type="camera">
-          <update_rate>30.0</update_rate>
-          <always_on>true</always_on>
-          <ignition_frame_id>camera_link</ignition_frame_id>
+    <gazebo reference="camera_link">
+      <sensor name="camera_link" type="camera">
+        <update_rate>30.0</update_rate>
+        <always_on>true</always_on>
+        <ignition_frame_id>camera_link</ignition_frame_id>
+        <xacro:if value="${camera_downward}">
+          <pose>0 0 0 0 ${CAMERA_ANGLE} 0</pose>
+        </xacro:if>
+        <xacro:unless value="${camera_downward}">
           <pose>0 0 0 0 0 0</pose>
-          <topic>/camera/color/image_raw</topic>
-          <camera name="rgb_camera">
-            <horizontal_fov>1.20428</horizontal_fov>
-            <image>
-              <width>1920</width>
-              <height>1080</height>
-              <format>R8G8B8</format>
-            </image>
-            <clip>
-              <near>0.02</near>
-              <far>300</far>
-            </clip>
-          </camera>
-        </sensor>
-      </gazebo>
-    </xacro:unless>
+        </xacro:unless>
+        <topic>/camera/color/image_raw</topic>
+        <camera name="rgb_camera">
+          <horizontal_fov>1.20428</horizontal_fov>
+          <image>
+            <width>1920</width>
+            <height>1080</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.02</near>
+            <far>300</far>
+          </clip>
+        </camera>
+      </sensor>
+    </gazebo>
   </xacro:if>
 </xacro:macro>
 

--- a/urdf/sensors/rgb_camera.xacro
+++ b/urdf/sensors/rgb_camera.xacro
@@ -45,7 +45,7 @@
           <update_rate>30.0</update_rate>
           <always_on>true</always_on>
           <ignition_frame_id>camera_link</ignition_frame_id>
-          <pose>0 0 0 0 0.523 0</pose>
+          <pose>0 0 0 0 ${radians(30)} 0</pose>
           <topic>/camera/color/image_raw</topic>
           <camera name="rgb_camera">
             <horizontal_fov>1.20428</horizontal_fov>

--- a/urdf/sensors/rgb_camera.xacro
+++ b/urdf/sensors/rgb_camera.xacro
@@ -6,17 +6,30 @@
   <xacro:macro name="rgb_camera_settings"
     params="use_gazebo
             use_rgb_camera
+            camera_downward
             ">
 
   <xacro:if value="$(arg use_rgb_camera)">
     <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
-    <xacro:sensor_d435
+    <xacro:if value="$(arg camera_downward)">
+      <xacro:sensor_d435
         parent="base_link"
         use_nominal_extrinsics="false"
         add_plug="false"
         use_mesh="true">
-      <origin xyz="0.08 0.0 0.055" rpy="0 0 0"/>
-    </xacro:sensor_d435>
+          <origin xyz="0.08 0.0 0.055" rpy="0 0.523 0"/>
+      </xacro:sensor_d435>
+    </xacro:if>
+
+    <xacro:unless value="$(arg camera_downward)">
+      <xacro:sensor_d435
+        parent="base_link"
+        use_nominal_extrinsics="false"
+        add_plug="false"
+        use_mesh="true">
+          <origin xyz="0.08 0.0 0.055" rpy="0 0 0"/>
+      </xacro:sensor_d435>
+    </xacro:unless>
   </xacro:if>
 
   <xacro:if value="${use_gazebo}">
@@ -26,27 +39,53 @@
       </plugin>
     </gazebo>
 
-    <gazebo reference="camera_link">
-      <sensor name="camera_link" type="camera">
-        <update_rate>30.0</update_rate>
-        <always_on>true</always_on>
-        <ignition_frame_id>camera_link</ignition_frame_id>
-        <pose>0 0 0 0 0 0</pose>
-        <topic>/camera/color/image_raw</topic>
-        <camera name="rgb_camera">
-          <horizontal_fov>1.20428</horizontal_fov>
-          <image>
-            <width>1920</width>
-            <height>1080</height>
-            <format>R8G8B8</format>
-          </image>
-          <clip>
-            <near>0.02</near>
-            <far>300</far>
-          </clip>
-        </camera>
-      </sensor>
-    </gazebo>
+    <xacro:if value="${camera_downward}">
+      <gazebo reference="camera_link">
+        <sensor name="camera_link" type="camera">
+          <update_rate>30.0</update_rate>
+          <always_on>true</always_on>
+          <ignition_frame_id>camera_link</ignition_frame_id>
+          <pose>0 0 0 0 0.523 0</pose>
+          <topic>/camera/color/image_raw</topic>
+          <camera name="rgb_camera">
+            <horizontal_fov>1.20428</horizontal_fov>
+            <image>
+              <width>1920</width>
+              <height>1080</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.02</near>
+              <far>300</far>
+            </clip>
+          </camera>
+        </sensor>
+      </gazebo>
+    </xacro:if>
+
+    <xacro:unless value="${camera_downward}">
+      <gazebo reference="camera_link">
+        <sensor name="camera_link" type="camera">
+          <update_rate>30.0</update_rate>
+          <always_on>true</always_on>
+          <ignition_frame_id>camera_link</ignition_frame_id>
+          <pose>0 0 0 0 0 0</pose>
+          <topic>/camera/color/image_raw</topic>
+          <camera name="rgb_camera">
+            <horizontal_fov>1.20428</horizontal_fov>
+            <image>
+              <width>1920</width>
+              <height>1080</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.02</near>
+              <far>300</far>
+            </clip>
+          </camera>
+        </sensor>
+      </gazebo>
+    </xacro:unless>
   </xacro:if>
 </xacro:macro>
 

--- a/urdf/sensors/rgb_camera.xacro
+++ b/urdf/sensors/rgb_camera.xacro
@@ -3,7 +3,7 @@
 
   <xacro:include filename="$(find raspimouse_description)/urdf/common.xacro" />
 
-  <xacro:property name="CAMERA_ANGLE" value="${radians(30)}"/>
+  <xacro:property name="DOWNWARD_CAMERA_ANGLE" value="${radians(30)}"/>
 
   <xacro:macro name="rgb_camera_settings"
     params="use_gazebo
@@ -19,7 +19,7 @@
         use_nominal_extrinsics="false"
         add_plug="false"
         use_mesh="true">
-          <origin xyz="0.08 0.0 0.055" rpy="0 ${CAMERA_ANGLE} 0"/>
+          <origin xyz="0.08 0.0 0.055" rpy="0 ${DOWNWARD_CAMERA_ANGLE} 0"/>
       </xacro:sensor_d435>
     </xacro:if>
 
@@ -47,7 +47,7 @@
         <always_on>true</always_on>
         <ignition_frame_id>camera_link</ignition_frame_id>
         <xacro:if value="${camera_downward}">
-          <pose>0 0 0 0 ${CAMERA_ANGLE} 0</pose>
+          <pose>0 0 0 0 ${DOWNWARD_CAMERA_ANGLE} 0</pose>
         </xacro:if>
         <xacro:unless value="${camera_downward}">
           <pose>0 0 0 0 0 0</pose>


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
camera_downwardをtrueにすると、RGBカメラのモデルが斜め30度下を向きます。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
下記のコマンドを実行すると、RGBカメラが斜め30度下を向いた状態になることをRViz上で確認できます。

```sh
ros2 launch raspimouse_description display.launch.py use_rgb_camera:=true camera_downward:=true
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
