### PR TITLE
ROS 2 Jazzy への対応

### DIFF
--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -20,7 +20,7 @@ jobs:
         ROS_REPO: [ros]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: "ros-industrial/industrial_ci@master"
         env:
           ROS_DISTRO: ${{ matrix.ROS_DISTRO }}

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -16,10 +16,12 @@ jobs:
   industrial_ci:
     strategy:
       matrix:
-        env:
-          - { ROS_DISTRO: humble, ROS_REPO: ros }
+        ROS_DISTRO: [jazzy]
+        ROS_REPO: [ros]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: "ros-industrial/industrial_ci@master"
-        env: ${{ matrix.env }}
+        env:
+          ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
+          ROS_REPO: ${{ matrix.ROS_REPO }}

--- a/README.md
+++ b/README.md
@@ -4,24 +4,23 @@ ROS package with URDF description macro for [Raspberry Pi Mouse](https://rt-net.
 
 ![display_launch](https://rt-net.github.io/images/raspberry-pi-mouse/display_launch.png)
 
-This ROS package was separated from [rt-net/raspimouse_sim](https://github.com/rt-net/raspimouse_sim).  
+This ROS package was separated from [rt-net/raspimouse_sim](https://github.com/rt-net/raspimouse_sim).
 See details from [rt-net/raspimouse_sim#42](https://github.com/rt-net/raspimouse_sim/pull/42).
 
-The main development branch for ROS 1 is [`master`](https://github.com/rt-net/raspimouse_description/tree/master).  
+The main development branch for ROS 1 is [`master`](https://github.com/rt-net/raspimouse_description/tree/master).
 The main development branch for ROS 2 is [`ros2`](https://github.com/rt-net/raspimouse_description/tree/ros2).
 
 ## Supported ROS distributions
 
-- Melodic ([`melodic-devel`](https://github.com/rt-net/raspimouse_description/tree/melodic-devel))
-- Foxy ([`foxy-devel`](https://github.com/rt-net/raspimouse_description/tree/foxy-devel))
-- Humble ([`humble-devel`](https://github.com/rt-net/raspimouse_description/tree/humble-devel))
+- Humble ([`humble`](https://github.com/rt-net/raspimouse_description/tree/humble))
+- Jazzy ([`jazzy`](https://github.com/rt-net/raspimouse_description/tree/jazzy))
 
 ## Installation
 
 ```sh
 # Clone raspimouse_description and install dependencies
 cd ~/ros2_ws/src
-git clone -b $ROS_DISTRO-devel https://github.com/rt-net/raspimouse_description
+git clone -b $ROS_DISTRO https://github.com/rt-net/raspimouse_description
 rosdep install -r -y -i --from-paths .
 
 # Build the package
@@ -66,7 +65,7 @@ ros2 launch raspimouse_description display.launch.py use_rgb_camera:=true camera
 
 (C) 2016-2022 RT Corporation
 
-This repository is licensed under the MIT license, see [LICENSE](./LICENSE).  
+This repository is licensed under the MIT license, see [LICENSE](./LICENSE).
 Unless attributed otherwise, everything in this repository is under the MIT license.
 
 ### Acknowledgements

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # raspimouse_description
 
+[![industrial_ci](https://github.com/rt-net/raspimouse_description/actions/workflows/industrial_ci.yml/badge.svg?branch=ros2)](https://github.com/rt-net/raspimouse_description/actions/workflows/industrial_ci.yml)
+
 ROS package with URDF description macro for [Raspberry Pi Mouse](https://rt-net.jp/products/raspberrypimousev3/)
 
 ![display_launch](https://rt-net.github.io/images/raspberry-pi-mouse/display_launch.png)

--- a/launch/display.launch.py
+++ b/launch/display.launch.py
@@ -14,13 +14,12 @@
 
 
 from ament_index_python.packages import get_package_share_directory
-from raspimouse_description.robot_description_loader import RobotDescriptionLoader
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.conditions import IfCondition
-from launch_ros.actions import Node
-from launch_ros.actions import PushRosNamespace
+from launch_ros.actions import Node, PushRosNamespace
 from launch.substitutions import LaunchConfiguration
+from raspimouse_description.robot_description_loader import RobotDescriptionLoader
 
 
 def generate_launch_description():

--- a/launch/display.launch.py
+++ b/launch/display.launch.py
@@ -17,8 +17,8 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.conditions import IfCondition
-from launch_ros.actions import Node, PushRosNamespace
 from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node, PushRosNamespace
 from raspimouse_description.robot_description_loader import RobotDescriptionLoader
 
 

--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="shop@rt-net.jp">RT Corporation</maintainer>
 
   <license>MIT</license>
-  
+
   <author email="daisuke.sato@rt-net.jp">Daisuke Sato</author>
   <author email="s.aoki@rt-net.jp">Shota Aoki</author>
   <author email="yusuke.kato@rt-net.jp">Yusuke Kato</author>
@@ -21,7 +21,7 @@
   <depend>urdf</depend>
   <depend>xacro</depend>
   <depend>launch</depend>
-  <depend>ign_ros2_control</depend>
+  <depend>gz_ros2_control</depend>
   <depend>realsense2_description</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
   <author email="daisuke.sato@rt-net.jp">Daisuke Sato</author>
   <author email="s.aoki@rt-net.jp">Shota Aoki</author>
   <author email="yusuke.kato@rt-net.jp">Yusuke Kato</author>
+  <author email="kurasawa@rt-net.jp">Kazushi Kurasawa</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/test/test_robot_description_loader.py
+++ b/test/test_robot_description_loader.py
@@ -19,10 +19,12 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from raspimouse_description.robot_description_loader import RobotDescriptionLoader
-from launch.launch_context import LaunchContext
-import pytest
 import math
+
+import pytest
+from launch.launch_context import LaunchContext
+from raspimouse_description.robot_description_loader import \
+    RobotDescriptionLoader
 
 
 def exec_load(loader):

--- a/test/test_robot_description_loader.py
+++ b/test/test_robot_description_loader.py
@@ -21,8 +21,9 @@
 
 import math
 
-import pytest
 from launch.launch_context import LaunchContext
+import pytest
+
 from raspimouse_description.robot_description_loader import \
     RobotDescriptionLoader
 

--- a/test/test_robot_description_loader.py
+++ b/test/test_robot_description_loader.py
@@ -91,7 +91,7 @@ def test_use_gazebo():
     rdl.use_gazebo = 'true'
     rdl.gz_control_config_package = 'raspimouse_description'
     rdl.gz_control_config_file_path = 'test/dummy_controllers.yaml'
-    assert 'ign_ros2_control/IgnitionSystem' in exec_load(rdl)
+    assert 'gz_ros2_control/GazeboSimSystem' in exec_load(rdl)
 
 
 def test_use_rgb_camera():

--- a/urdf/raspimouse.urdf.xacro
+++ b/urdf/raspimouse.urdf.xacro
@@ -17,7 +17,7 @@
   <xacro:arg name="camera_downward" default="false" />
   <xacro:arg name="gz_control_config_package" default="" />
   <xacro:arg name="gz_control_config_file_path" default="" />
-  
+
   <material name="black">
     <color rgba="0.2 0.2 0.2 1.0"/>
   </material>
@@ -109,7 +109,7 @@
   <xacro:if value="$(arg use_gazebo)">
     <xacro:gazebo_diffdrive_settings
       use_gazebo="$(arg use_gazebo)"
-      config_file_package="$(arg gz_control_config_package)" 
+      config_file_package="$(arg gz_control_config_package)"
       config_file_path="$(arg gz_control_config_file_path)" />
 
     <xacro:diffdrive_gazebo_ros2_control_settings

--- a/urdf/sensors/lidar.gazebo.xacro
+++ b/urdf/sensors/lidar.gazebo.xacro
@@ -5,7 +5,7 @@
     <gazebo reference="${sensor_link_name}">
       <sensor type="gpu_lidar" name="${sensor_link_name}_sensor">
         <pose relative_to='${sensor_link_name}'>0 0 0 0 0 0</pose>
-        <ignition_frame_id>${sensor_link_name}</ignition_frame_id>
+        <gz_frame_id>${sensor_link_name}</gz_frame_id>
         <frame_id>${sensor_link_name}</frame_id>
         <topic>scan</topic>
         <always_on>1</always_on>

--- a/urdf/sensors/lightsens.urdf.xacro
+++ b/urdf/sensors/lightsens.urdf.xacro
@@ -16,8 +16,8 @@
         <geometry>
           <box size="0.01 0.005 0.007" />
         </geometry>
-        <material name="Gray">
-          <color rgba="0.2 0.2 0.2 1" />
+        <material name="Red">
+          <color rgba="1.0 0.0 0.0 1" />
         </material>
       </visual>
       <inertial>

--- a/urdf/sensors/rgb_camera.xacro
+++ b/urdf/sensors/rgb_camera.xacro
@@ -32,19 +32,19 @@
             <origin xyz="0.08 0.0 0.055" rpy="0 0 0"/>
         </xacro:sensor_d435>
       </xacro:unless>
-  
+
       <xacro:if value="${use_gazebo}">
         <gazebo>
-          <plugin filename="ignition-gazebo-sensors-system" name="ignition::gazebo::systems::Sensors">
+          <plugin filename="gz-sim-sensors-system" name="gz::sim::systems::Sensors">
             <render_engine>ogre2</render_engine>
           </plugin>
         </gazebo>
-    
+
         <gazebo reference="camera_link">
           <sensor name="camera_link" type="camera">
             <update_rate>30.0</update_rate>
             <always_on>true</always_on>
-            <ignition_frame_id>camera_link</ignition_frame_id>
+            <gz_frame_id>camera_link</gz_frame_id>
             <xacro:if value="${camera_downward}">
               <pose>0 0 0 0 ${DOWNWARD_CAMERA_ANGLE} 0</pose>
             </xacro:if>

--- a/urdf/wheel/diffdrive.gazebo.xacro
+++ b/urdf/wheel/diffdrive.gazebo.xacro
@@ -13,7 +13,7 @@
       <xacro:if value="${use_gazebo}">
         <plugin filename="libgz_ros2_control-system.so" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
           <ros>
-            <remapping>diff_drive_controller/cmd_vel_unstamped:=cmd_vel</remapping>
+            <remapping>diff_drive_controller/cmd_vel:=cmd_vel</remapping>
             <remapping>diff_drive_controller/odom:=odom</remapping>
           </ros>
           <parameters>$(find ${config_file_package})/${config_file_path}</parameters>

--- a/urdf/wheel/diffdrive.gazebo.xacro
+++ b/urdf/wheel/diffdrive.gazebo.xacro
@@ -11,7 +11,7 @@
 
     <gazebo>
       <xacro:if value="${use_gazebo}">
-        <plugin filename="libign_ros2_control-system.so" name="ign_ros2_control::IgnitionROS2ControlPlugin">
+        <plugin filename="libgz_ros2_control-system.so" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
           <ros>
             <remapping>diff_drive_controller/cmd_vel_unstamped:=cmd_vel</remapping>
             <remapping>diff_drive_controller/odom:=odom</remapping>

--- a/urdf/wheel/diffdrive.gazebo_ros2_control.xacro
+++ b/urdf/wheel/diffdrive.gazebo_ros2_control.xacro
@@ -10,7 +10,7 @@
 
     <ros2_control name="${name_hardware}" type="system">
       <hardware>
-        <plugin>ign_ros2_control/IgnitionSystem</plugin>
+        <plugin>gz_ros2_control/GazeboSimSystem</plugin>
       </hardware>
 
       <joint name="${name_right_wheel_joint}">


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

ROS 2 Jazzy（+ Gazebo Harmonic）に対応させる修正を行います。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

## 環境

- Ubuntu Desktop 24.04
- ROS 2 Jazzy Jalisco
- RViz version 14.1.5 
    - Compiled against Qt version 5.15.13.
    - Compiled against OGRE version 1.12.10 (Rhagorthua).

## 手順

READMEに記述してある手順を実施し、RobotModelを表示できていることを確認しました。

ノーマルなRaspberry Pi Mouseを表示

```bash
$ ros2 launch raspimouse_description display.launch.py
```

RPLiDARを搭載したRaspberry Pi Mouseを表示

```bash
$ ros2 launch raspimouse_description display.launch.py lidar:=rplidar
```

RGBカメラを搭載したRaspberry Pi Mouseを表示

```bash
$ ros2 launch raspimouse_description display.launch.py use_rgb_camera:=true

```
![image](https://github.com/user-attachments/assets/b8bc73bb-641a-40fa-ba31-2c7b07aa7509)

# Any other comments?
<!-- その他コメントはありますか？ -->

## 主な変更点

- 距離センサの色を赤色に変更
- `Ignition`から`Gazebo`への命名変更対応

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
