### PR TITLE
rempappingの記述の削除

### DIFF
--- a/urdf/wheel/diffdrive.gazebo.xacro
+++ b/urdf/wheel/diffdrive.gazebo.xacro
@@ -12,10 +12,6 @@
     <gazebo>
       <xacro:if value="${use_gazebo}">
         <plugin filename="libgz_ros2_control-system.so" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
-          <ros>
-            <remapping>diff_drive_controller/cmd_vel:=cmd_vel</remapping>
-            <remapping>diff_drive_controller/odom:=odom</remapping>
-          </ros>
           <parameters>$(find ${config_file_package})/${config_file_path}</parameters>
         </plugin>
       </xacro:if>


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
`gz_ros2_control`プラグイン内に記述していた、`diff_drive_controller`の`cmd_vel`および`odom`に対するリマッピングを削除します。

ROS 2 Lyricalでは、[controller_managerのROS引数を、生成する各controllerへ`NodeOptions`経由で転送する処理が廃止](https://control.ros.org/lyrical/doc/ros2_control/doc/release_notes.html#controller-manager)されました。これにより、controller_manager側で指定したリマッピングは`diff_drive_controller`へ適用されなくなり、今回削除する記述は効果のない設定となっています。

Lyricalでは、controller起動側から[spawnerの`--controller-ros-args`](https://control.ros.org/lyrical/doc/ros2_control/controller_manager/doc/userdoc.html#spawner)を使用し、リマッピングを各controllerへ明示的に渡す必要があります。そのため、リマッピングの設定は`raspimouse_description`ではなく、controllerを起動するパッケージ側で行います。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

現在Lyrical対応中のraspimouse_simパッケージの`feature/support-lyrical`ブランチから呼び出し、`/cmd_vel`で動作することを確認しました。

# Any other comments?
<!-- その他コメントはありますか？ -->

現在Lyrical対応中の`raspimouse_sim`では、spawnerからリマッピングを明示的に渡す構成により、`/cmd_vel`を使用したGazebo上での走行を確認しています。Lyrical環境では、本パッケージとLyrical対応版`raspimouse_sim`（feature/support-lyrical ブランチ）を組み合わせた動作確認を推奨します。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
